### PR TITLE
Fix order of linked libraries for Intel compilers

### DIFF
--- a/PyUQTk/pce/CMakeLists.txt
+++ b/PyUQTk/pce/CMakeLists.txt
@@ -67,7 +67,7 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 	SWIG_LINK_LIBRARIES(pce m lapack ${LAPACK_LIBRARIES})
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
 	# using Intel
-  SWIG_LINK_LIBRARIES(pce uqtktools uqtkquad uqtkarray depslatec depdsfmt depann depfigtree depcvode ifcore ${PYTHON_LIBRARIES})
+	SWIG_LINK_LIBRARIES(pce uqtkquad uqtkarray uqtktools depslatec depdsfmt depfigtree depann ifcore ${PYTHON_LIBRARIES})
 	SWIG_LINK_LIBRARIES(pce m blas ${BLAS_LIBRARIES})
 	SWIG_LINK_LIBRARIES(pce m lapack ${LAPACK_LIBRARIES})
 endif()


### PR DESCRIPTION
You can't possibly build the PyUQTk on Intel compilers due to wrong `depcvode` lib.

Also due to wrong order of libs code will compile, but 3 tests will fail because resulting .so Python libs have missing/undefined symbols in `_pce.so`.

Stating them here for others solving this issue:
`_Z13annDeallocPtsRPPd`
`_Z6gq_genR7Array1DIdES1_dS1_S1_`

3 failing tests:
```
24:PyModTest
28:PyBCSTest
29:PyBADPTest


Traceback (most recent call last):
  File "PyModTest.py", line 48, in <module>
    import pce
  File "../pce/pce.py", line 15, in <module>
    import _pce
ImportError: ../pce/_pce.so: undefined symbol: _Z13annDeallocPtsRPPd

PyUQTk array and quad module not foundbcs       
Traceback (most recent call last):
  File "PyBCSTest.py", line 91, in <module>
    regmodel = bcsreg(ndim=2,pcorder=pcorder,pctype="LU")
NameError: name 'bcsreg' is not defined

PyUQTk array, quad, pce, tools, pce_tools or adaptation_tools modules not found
Traceback (most recent call last):
  File "PyBADPTest.py", line 134, in <module>
    nord0, ndim, pc_type, param0, R0,main_verbose, sf)
  File "PyBADPTest.py", line 77, in forward_propagation
    pc_model = uqtkpce.PCSet("NISP", nord,ndim,pc_type, 0.0, 1.0)
NameError: name 'uqtkpce' is not defined
```