### PR TITLE
more accurate ImportError messages

### DIFF
--- a/PyUQTk/__init__.py
+++ b/PyUQTk/__init__.py
@@ -27,49 +27,60 @@
 #=====================================================================================
 # swig interface modules (only compiled if PyUQTK=On)
 try:
-	from . import uqtkarray
-except ImportError:
-	print('PyUQTk SWIG array interface not created.')
+    from . import uqtkarray
+except ImportError as ie:
+    print('PyUQTk SWIG uqtkarray interface not imported.', ie)
 
 try:
-	from . import quad
-except ImportError:
-	print('PyUQTk SWIG quad interface not created.')
+    from . import quad
+except ImportError as ie:
+    print('PyUQTk SWIG quad interface not imported.', ie)
 
 try:
-	from . import tools
-except ImportError:
-	print('PyUQTk SWIG tools interface not created.')
+    from . import tools
+except ImportError as ie:
+    print('PyUQTk SWIG tools interface not imported.', ie)
 
 try:
-	from . import kle
-except ImportError:
-	print('PyUQTk SWIG kle interface not created.')
+    from . import kle
+except ImportError as ie:
+    print('PyUQTk SWIG kle interface not imported.', ie)
 
 try:
-	from . import pce
-	from . import PyPCE
-except ImportError:
-	print('PyUQTk SWIG pce interface and PyPCE module not available.')
+    from . import pce
+except ImportError as ie:
+    print('PyUQTk SWIG pce interface not imported.', ie)
 
 try:
-	from . import bcs
-except ImportError:
-	print('PyUQTk SWIG bcs interface not created.')
+    from . import PyPCE
+except ImportError as ie:
+    print('PyUQTk SWIG PyPCE module not imported.', ie)
 
 try:
-	from . import mcmc
-except ImportError:
-	print('PyUQTk SWIG mcmc interface not created.')
+    from . import bcs
+except ImportError as ie:
+    print('PyUQTk SWIG bcs interface not imported.', ie)
+
+try:
+    from . import mcmc
+except ImportError as ie:
+    print('PyUQTk SWIG mcmc interface not imported.', ie)
 
 # pure python tools (always included)
 try:
-	from . import inference
-	from . import plotting
-	from . import sens
-except:
-	print('Scipy and/or matplotlib may need to be installed')
+    from . import inference
+except ImportError as ie:
+    print('Scipy and/or matplotlib may need to be installed', ie)
 
+try:
+    from . import plotting
+except ImportError as ie:
+    print('Scipy and/or matplotlib may need to be installed', ie)
+
+try:
+    from . import sens
+except ImportError as ie:
+    print('Scipy and/or matplotlib may need to be installed', ie)
 
 from . import utils
 from . import multirun


### PR DESCRIPTION
The changes to the ImportError exception messages are more useful when debugging issues with dependencies and environment variables required by PyUQTk.

Addresses #2 